### PR TITLE
Update gradle-docker-ci.yml

### DIFF
--- a/.github/workflows/gradle-docker-ci.yml
+++ b/.github/workflows/gradle-docker-ci.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Run Unit Tests
       run: ./gradlew build
     - name: Publish
-      if: branch = master
+      if: github.ref == 'refs/heads/master'
       run: |
         mkdir -p ~/.gradle
         echo "gradle.publish.key=${GRADLE_PUBLISH_KEY}" >> ~/.gradle/gradle.properties


### PR DESCRIPTION
PR to merge into dev branch and see if still has desired functionality of running tests but not publishing